### PR TITLE
Prime house scraper session and publish data outputs

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -32,6 +32,9 @@ jobs:
     - name: Run scraper
       run: npm run fetch
 
+    - name: Build published data
+      run: npm run build:data
+
     - name: Verify output and commit
       run: |
         echo "=== Output files ==="
@@ -46,7 +49,19 @@ jobs:
         echo "=== Debug log tail ==="
         tail -5 output/debug.log 2>/dev/null || echo "debug.log missing"
         echo ""
-        
+
+        echo "=== Published docs/data ==="
+        ls -la docs/data/
+        echo ""
+
+        echo "=== Published House data sample ==="
+        head -5 docs/data/house.json 2>/dev/null || echo "docs/data/house.json missing"
+        echo ""
+
+        echo "=== Published Senate data sample ==="
+        head -5 docs/data/senate.json 2>/dev/null || echo "docs/data/senate.json missing"
+        echo ""
+
         echo "=== Git status ==="
         git status
         echo ""
@@ -54,9 +69,9 @@ jobs:
         echo "=== Configuring git ==="
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        
+
         echo "=== Adding files ==="
-        git add output/ -v
+        git add output/ docs/data/ -v
         
         if git diff --staged --quiet; then
           echo "✅ No changes to commit - data is already up to date"


### PR DESCRIPTION
## Summary
- warm the House scraper context with saved storage state and a site navigation before POSTing, then reuse it across retries
- adjust the House API headers and post helper so the Origin matches the browser and contexts can be reused while persisting cookies
- extend the scheduled workflow to rebuild docs/data assets, add logging for the published files, and commit them with the scraper output

## Testing
- npm run fetch *(fails: Playwright browsers not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd59abe25c832b8cf39b71e36c96fa