### PR TITLE
Implement month grid calendar view

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -3,7 +3,8 @@ const state = {
   branches: new Set(['House of Representatives', 'Senate']),
   startDate: '',
   endDate: '',
-  showPast: false
+  showPast: false,
+  view: 'list'
 };
 
 const elements = {
@@ -21,11 +22,14 @@ const elements = {
   countSenate: document.getElementById('count-senate'),
   resultsCount: document.getElementById('results-count'),
   resultsList: document.getElementById('results-list'),
+  resultsCalendar: document.getElementById('results-calendar'),
+  viewButtons: Array.from(document.querySelectorAll('.view-toggle__button')),
   noResults: document.getElementById('no-results')
 };
 
 let records = [];
 let metadata = null;
+let filteredRecords = [];
 
 const dateFormatter = new Intl.DateTimeFormat('en-PH', {
   weekday: 'short',
@@ -33,6 +37,13 @@ const dateFormatter = new Intl.DateTimeFormat('en-PH', {
   day: 'numeric',
   year: 'numeric'
 });
+
+const monthFormatter = new Intl.DateTimeFormat('en-PH', {
+  month: 'long',
+  year: 'numeric'
+});
+
+const weekdayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 function toStartOfDay(date) {
   const copy = new Date(date);
@@ -59,6 +70,29 @@ function sanitizeAgenda(agenda) {
   return agenda.replace(/\s*\u2022\s*/g, ' • ').trim();
 }
 
+function parseDate(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function compareRecords(a, b) {
+  const dateA = parseDate(a.isoDate);
+  const dateB = parseDate(b.isoDate);
+
+  if (dateA && dateB) {
+    return dateA - dateB;
+  }
+  if (dateA) return -1;
+  if (dateB) return 1;
+
+  if (a.time && b.time) {
+    return a.time.localeCompare(b.time);
+  }
+
+  return (a.committee || '').localeCompare(b.committee || '');
+}
+
 function computeSearchText(record) {
   if (record.searchText) return record.searchText;
   return [
@@ -76,7 +110,7 @@ function computeSearchText(record) {
 
 function applyFilters() {
   const today = toStartOfDay(new Date());
-  const filtered = records.filter((record) => {
+  filteredRecords = records.filter((record) => {
     if (!state.branches.has(record.branch)) return false;
 
     if (state.search) {
@@ -106,82 +140,318 @@ function applyFilters() {
     return true;
   });
 
-  renderResults(filtered);
+  renderResults(filteredRecords);
+}
+
+function createRecordCard(record) {
+  const card = document.createElement('article');
+  card.className = 'result-card';
+
+  const header = document.createElement('div');
+  header.className = 'result-card__header';
+
+  const branch = document.createElement('span');
+  branch.className = 'result-card__branch';
+  branch.textContent = record.branch;
+
+  const title = document.createElement('h2');
+  title.className = 'result-card__title';
+  title.textContent = record.committee || 'Untitled committee';
+
+  header.append(branch, title);
+
+  const badge = document.createElement('span');
+  badge.className = 'result-card__badge';
+  badge.textContent = `Status: ${record.status || 'Scheduled'}`;
+
+  const meta = document.createElement('div');
+  meta.className = 'result-card__meta';
+
+  const date = document.createElement('span');
+  date.textContent = `🗓️ ${formatDate(record)}`;
+
+  const time = document.createElement('span');
+  time.textContent = `⏰ ${formatTime(record)}`;
+
+  const venue = document.createElement('span');
+  venue.textContent = `📍 ${record.venue || 'Venue TBA'}`;
+
+  meta.append(date, time, venue);
+
+  const agenda = document.createElement('p');
+  agenda.className = 'result-card__agenda';
+  agenda.textContent = sanitizeAgenda(record.agenda);
+
+  const parts = [header, badge, meta, agenda];
+
+  if (record.notes) {
+    const notes = document.createElement('p');
+    notes.className = 'result-card__notes';
+    notes.textContent = record.notes;
+    parts.push(notes);
+  }
+
+  if (record.source) {
+    const source = document.createElement('p');
+    source.className = 'result-card__notes';
+    source.textContent = `Source: ${record.source}`;
+    parts.push(source);
+  }
+
+  parts.forEach((el) => card.appendChild(el));
+  return card;
+}
+
+function renderListView(items) {
+  const fragment = document.createDocumentFragment();
+
+  items.forEach((record) => {
+    fragment.appendChild(createRecordCard(record));
+  });
+
+  elements.resultsList.appendChild(fragment);
+}
+
+function renderCalendarView(items) {
+  const months = new Map();
+  const undated = [];
+
+  items.forEach((record) => {
+    const iso = record.isoDate || (record.date ? `${record.date}T00:00:00` : '');
+    const parsed = parseDate(iso);
+
+    if (!parsed) {
+      undated.push(record);
+      return;
+    }
+
+    const normalized = toStartOfDay(parsed);
+    const monthKey = `${normalized.getFullYear()}-${String(normalized.getMonth() + 1).padStart(2, '0')}`;
+
+    if (!months.has(monthKey)) {
+      months.set(monthKey, {
+        monthDate: new Date(normalized.getFullYear(), normalized.getMonth(), 1),
+        days: new Map()
+      });
+    }
+
+    const monthData = months.get(monthKey);
+    const day = normalized.getDate();
+    if (!monthData.days.has(day)) {
+      monthData.days.set(day, []);
+    }
+    monthData.days.get(day).push(record);
+  });
+
+  const fragment = document.createDocumentFragment();
+  const sortedMonths = Array.from(months.values()).sort((a, b) => a.monthDate - b.monthDate);
+
+  sortedMonths.forEach((monthData) => {
+    const section = document.createElement('section');
+    section.className = 'calendar-month';
+
+    const header = document.createElement('header');
+    header.className = 'calendar-month__header';
+
+    const title = document.createElement('h3');
+    title.className = 'calendar-month__title';
+    title.textContent = monthFormatter.format(monthData.monthDate);
+
+    const hearingsCount = Array.from(monthData.days.values()).reduce(
+      (total, events) => total + events.length,
+      0
+    );
+
+    const count = document.createElement('span');
+    count.className = 'calendar-month__count';
+    count.textContent = `${hearingsCount} hearing${hearingsCount === 1 ? '' : 's'}`;
+
+    header.append(title, count);
+    section.appendChild(header);
+
+    const grid = document.createElement('div');
+    grid.className = 'calendar-month__grid';
+
+    weekdayLabels.forEach((label) => {
+      const weekday = document.createElement('div');
+      weekday.className = 'calendar-month__weekday';
+      weekday.textContent = label;
+      grid.appendChild(weekday);
+    });
+
+    const firstWeekday = monthData.monthDate.getDay();
+    for (let index = 0; index < firstWeekday; index += 1) {
+      const filler = document.createElement('div');
+      filler.className = 'calendar-month__cell calendar-month__cell--inactive';
+      grid.appendChild(filler);
+    }
+
+    const year = monthData.monthDate.getFullYear();
+    const monthIndex = monthData.monthDate.getMonth();
+    const daysInMonth = new Date(year, monthIndex + 1, 0).getDate();
+
+    for (let day = 1; day <= daysInMonth; day += 1) {
+      const cell = document.createElement('div');
+      cell.className = 'calendar-month__cell';
+
+      const dateLabel = document.createElement('div');
+      dateLabel.className = 'calendar-month__date';
+      dateLabel.textContent = day;
+      cell.appendChild(dateLabel);
+
+      const dailyEvents = monthData.days.get(day);
+
+      if (dailyEvents && dailyEvents.length) {
+        const eventsContainer = document.createElement('div');
+        eventsContainer.className = 'calendar-month__events';
+
+        dailyEvents
+          .slice()
+          .sort(compareRecords)
+          .forEach((record) => {
+            const eventEl = document.createElement('article');
+            eventEl.className = 'calendar-month__event';
+
+            const eventHeader = document.createElement('div');
+            eventHeader.className = 'calendar-month__event-row';
+
+            const time = document.createElement('span');
+            time.className = 'calendar-month__event-time';
+            time.textContent = `⏰ ${formatTime(record)}`;
+
+            const status = document.createElement('span');
+            status.className = 'calendar-month__event-status';
+            status.textContent = record.status
+              ? `Status: ${record.status}`
+              : 'Status: Scheduled';
+
+            eventHeader.append(time, status);
+
+            const titleEl = document.createElement('h4');
+            titleEl.className = 'calendar-month__event-title';
+            titleEl.textContent = record.committee || 'Untitled committee';
+
+            const meta = document.createElement('div');
+            meta.className = 'calendar-month__event-meta';
+
+            const branch = document.createElement('span');
+            branch.textContent = `🏛️ ${record.branch}`;
+
+            const venue = document.createElement('span');
+            venue.textContent = `📍 ${record.venue || 'Venue TBA'}`;
+
+            meta.append(branch, venue);
+
+            const agenda = document.createElement('p');
+            agenda.className = 'calendar-month__event-agenda';
+            agenda.textContent = sanitizeAgenda(record.agenda);
+
+            eventEl.append(eventHeader, titleEl, meta, agenda);
+
+            if (record.notes) {
+              const notes = document.createElement('p');
+              notes.className = 'calendar-month__event-notes';
+              notes.textContent = record.notes;
+              eventEl.appendChild(notes);
+            }
+
+            if (record.source) {
+              const source = document.createElement('p');
+              source.className = 'calendar-month__event-notes';
+              source.textContent = `Source: ${record.source}`;
+              eventEl.appendChild(source);
+            }
+
+            eventsContainer.appendChild(eventEl);
+          });
+
+        cell.appendChild(eventsContainer);
+      } else {
+        cell.classList.add('calendar-month__cell--quiet');
+      }
+
+      grid.appendChild(cell);
+    }
+
+    const trailing = (firstWeekday + daysInMonth) % 7;
+    if (trailing) {
+      for (let index = trailing; index < 7; index += 1) {
+        const filler = document.createElement('div');
+        filler.className = 'calendar-month__cell calendar-month__cell--inactive';
+        grid.appendChild(filler);
+      }
+    }
+
+    section.appendChild(grid);
+    fragment.appendChild(section);
+  });
+
+  if (undated.length) {
+    const section = document.createElement('section');
+    section.className = 'calendar-month calendar-month--tbd';
+
+    const header = document.createElement('header');
+    header.className = 'calendar-month__header';
+
+    const title = document.createElement('h3');
+    title.className = 'calendar-month__title';
+    title.textContent = 'Date to be determined';
+
+    const count = document.createElement('span');
+    count.className = 'calendar-month__count';
+    count.textContent = `${undated.length} hearing${undated.length === 1 ? '' : 's'}`;
+
+    header.append(title, count);
+    section.appendChild(header);
+
+    const list = document.createElement('div');
+    list.className = 'calendar-month__tbd-list';
+
+    undated
+      .slice()
+      .sort(compareRecords)
+      .forEach((record) => {
+        list.appendChild(createRecordCard(record));
+      });
+
+    section.appendChild(list);
+    fragment.appendChild(section);
+  }
+
+  elements.resultsCalendar.appendChild(fragment);
+}
+
+function updateViewButtons() {
+  elements.viewButtons.forEach((button) => {
+    const isActive = button.dataset.view === state.view;
+    button.classList.toggle('view-toggle__button--active', isActive);
+    button.setAttribute('aria-pressed', String(isActive));
+  });
 }
 
 function renderResults(items) {
   elements.resultsList.innerHTML = '';
-  elements.noResults.hidden = items.length > 0;
+  elements.resultsCalendar.innerHTML = '';
+
+  const hasItems = items.length > 0;
+
+  elements.noResults.hidden = hasItems;
   elements.resultsCount.textContent = `${items.length.toLocaleString()} hearing${
     items.length === 1 ? '' : 's'
   } shown`;
 
-  if (!items.length) {
+  elements.resultsList.hidden = !hasItems || state.view !== 'list';
+  elements.resultsCalendar.hidden = !hasItems || state.view !== 'calendar';
+
+  if (!hasItems) {
     return;
   }
 
-  const fragment = document.createDocumentFragment();
-
-  items.forEach((record) => {
-    const card = document.createElement('article');
-    card.className = 'result-card';
-
-    const header = document.createElement('div');
-    header.className = 'result-card__header';
-
-    const branch = document.createElement('span');
-    branch.className = 'result-card__branch';
-    branch.textContent = record.branch;
-
-    const title = document.createElement('h2');
-    title.className = 'result-card__title';
-    title.textContent = record.committee || 'Untitled committee';
-
-    header.append(branch, title);
-
-    const badge = document.createElement('span');
-    badge.className = 'result-card__badge';
-    badge.textContent = `Status: ${record.status || 'Scheduled'}`;
-
-    const meta = document.createElement('div');
-    meta.className = 'result-card__meta';
-
-    const date = document.createElement('span');
-    date.textContent = `🗓️ ${formatDate(record)}`;
-
-    const time = document.createElement('span');
-    time.textContent = `⏰ ${formatTime(record)}`;
-
-    const venue = document.createElement('span');
-    venue.textContent = `📍 ${record.venue || 'Venue TBA'}`;
-
-    meta.append(date, time, venue);
-
-    const agenda = document.createElement('p');
-    agenda.className = 'result-card__agenda';
-    agenda.textContent = sanitizeAgenda(record.agenda);
-
-    const parts = [header, badge, meta, agenda];
-
-    if (record.notes) {
-      const notes = document.createElement('p');
-      notes.className = 'result-card__notes';
-      notes.textContent = record.notes;
-      parts.push(notes);
-    }
-
-    if (record.source) {
-      const source = document.createElement('p');
-      source.className = 'result-card__notes';
-      source.textContent = `Source: ${record.source}`;
-      parts.push(source);
-    }
-
-    parts.forEach((el) => card.appendChild(el));
-    fragment.appendChild(card);
-  });
-
-  elements.resultsList.appendChild(fragment);
+  if (state.view === 'list') {
+    renderListView(items);
+  } else {
+    renderCalendarView(items);
+  }
 }
 
 function updateStats() {
@@ -276,6 +546,18 @@ function attachEventListeners() {
   });
 
   elements.reset.addEventListener('click', resetFilters);
+
+  elements.viewButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const view = button.dataset.view;
+      if (!view || view === state.view) return;
+      state.view = view;
+      updateViewButtons();
+      renderResults(filteredRecords);
+    });
+  });
+
+  updateViewButtons();
 }
 
 async function loadData() {

--- a/docs/index.html
+++ b/docs/index.html
@@ -100,8 +100,29 @@
       </section>
 
       <section class="results" aria-live="polite" aria-label="Committee hearings">
-        <div id="results-count" class="results__count">Loading schedules…</div>
+        <div class="results__header">
+          <div id="results-count" class="results__count">Loading schedules…</div>
+          <div class="view-toggle" role="group" aria-label="Display options">
+            <button
+              type="button"
+              class="view-toggle__button view-toggle__button--active"
+              data-view="list"
+              aria-pressed="true"
+            >
+              List view
+            </button>
+            <button
+              type="button"
+              class="view-toggle__button"
+              data-view="calendar"
+              aria-pressed="false"
+            >
+              Month view
+            </button>
+          </div>
+        </div>
         <div id="results-list" class="results__list"></div>
+        <div id="results-calendar" class="results__calendar" hidden></div>
         <div id="no-results" class="results__empty" hidden>
           <p>No hearings match the selected filters. Try adjusting the date range or search keywords.</p>
         </div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -207,9 +207,222 @@ a:focus {
   font-weight: 700;
 }
 
+.results__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
 .results__count {
   font-weight: 600;
-  margin-bottom: 1rem;
+}
+
+.view-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.25rem;
+}
+
+.view-toggle__button {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-weight: 600;
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.view-toggle__button:hover,
+.view-toggle__button:focus {
+  color: var(--accent);
+  outline: none;
+}
+
+.view-toggle__button--active {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 6px 16px -12px rgba(37, 99, 235, 0.9);
+}
+
+.results__calendar {
+  display: grid;
+  gap: 2rem;
+}
+
+.calendar-month {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.calendar-month__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.calendar-month__title {
+  margin: 0;
+  font-size: clamp(1.25rem, 2.5vw, 1.6rem);
+  font-weight: 700;
+}
+
+.calendar-month__count {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.calendar-month__grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(7, minmax(130px, 1fr));
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+.calendar-month__grid::-webkit-scrollbar {
+  height: 8px;
+}
+
+.calendar-month__grid::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.calendar-month__grid::-webkit-scrollbar-thumb {
+  background: rgba(37, 99, 235, 0.3);
+  border-radius: 999px;
+}
+
+.calendar-month__grid {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(37, 99, 235, 0.3) transparent;
+}
+
+.calendar-month__weekday {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: var(--muted);
+  text-align: center;
+  padding: 0.25rem 0;
+}
+
+.calendar-month__cell {
+  min-height: 8rem;
+  padding: 0.75rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: var(--accent-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.calendar-month__cell--quiet {
+  background: transparent;
+  border-style: dashed;
+}
+
+.calendar-month__cell--inactive {
+  min-height: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
+.calendar-month__date {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.calendar-month__cell--quiet .calendar-month__date {
+  color: var(--muted);
+}
+
+.calendar-month__events {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.calendar-month__event {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 0.65rem 0.75rem;
+  display: grid;
+  gap: 0.4rem;
+  box-shadow: 0 12px 24px -22px rgba(37, 99, 235, 0.8);
+}
+
+.calendar-month__event-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.calendar-month__event-time {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.calendar-month__event-status {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.calendar-month__event-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.calendar-month__event-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.calendar-month__event-agenda {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.calendar-month__event-notes {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.calendar-month__tbd-list {
+  display: grid;
+  gap: 1.15rem;
+}
+
+@media (max-width: 768px) {
+  .calendar-month__grid {
+    grid-template-columns: repeat(7, minmax(110px, 1fr));
+  }
 }
 
 .results__list {
@@ -337,5 +550,20 @@ a:focus {
   .result-card__meta {
     flex-direction: column;
     gap: 0.4rem;
+  }
+
+  .results__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .view-toggle {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .view-toggle__button {
+    flex: 1;
+    text-align: center;
   }
 }


### PR DESCRIPTION
## Summary
- add a view toggle that lets users switch between list and month layouts
- render hearings in multi-month calendar grids with weekday columns and weekly rows while keeping filters
- style the month view cells, events, and date-TBD fallback for desktop and mobile

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1f62a4a54832ba843bedd9c89041e