### PR TITLE
Fix Senate branch normalization

### DIFF
--- a/src/lib/load-events.ts
+++ b/src/lib/load-events.ts
@@ -23,7 +23,7 @@ const DATA_FILE_PATH = path.join(process.cwd(), 'docs', 'data', 'all.json');
 function normalizeBranch(branch?: string): EventBranch | null {
   if (!branch) return null;
   const normalized = branch.trim().toLowerCase();
-  if (normalized === 'senate') return 'Senate';
+  if (normalized === 'senate' || normalized.startsWith('senate ')) return 'Senate';
   if (normalized.startsWith('house')) return 'House of Representatives';
   return null;
 }


### PR DESCRIPTION
## Summary
- allow the event loader to treat branch labels that begin with "Senate" as Senate data so records remain visible even when the scraped label includes extra words

## Testing
- not run (Next.js lint command prompts for interactive configuration)

------
https://chatgpt.com/codex/tasks/task_e_68e263b73490832b950a63276104b64d