### PR TITLE
Add branch-aware color coding to calendar events

### DIFF
--- a/src/components/calendar/calendar-view.tsx
+++ b/src/components/calendar/calendar-view.tsx
@@ -19,6 +19,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { Event } from '@/lib/types';
 import { cn } from '@/lib/utils';
+import { getEventColors } from '@/lib/event-colors';
 import { EventDetails } from './event-details';
 import EventIcon from '../icons/event-icon';
 import { DayEventsDialog } from './day-events-dialog';
@@ -106,22 +107,32 @@ export function CalendarView({ events }: CalendarViewProps) {
                   <div className="mt-1 space-y-1">
                     {sortedDayEvents
                       .slice(0, 2)
-                      .map((event) => (
-                        <button
-                          key={event.id}
-                          onClick={() => setSelectedEvent(event)}
-                          className="w-full text-left p-1.5 rounded-lg bg-primary/20 hover:bg-primary/40 transition-colors"
-                          aria-label={`View event: ${event.committee}`}
-                        >
-                          <div className="flex items-center gap-1.5">
-                            <EventIcon branch={event.branch} className="h-3 w-3 text-accent flex-shrink-0" />
-                            <span className="text-[11px] font-medium text-accent truncate">
-                              {event.time ? `${event.time} · ` : ''}
-                              {event.committee}
-                            </span>
-                          </div>
-                        </button>
-                      ))}
+                      .map((event) => {
+                        const colors = getEventColors(event);
+                        return (
+                          <button
+                            key={event.id}
+                            onClick={() => setSelectedEvent(event)}
+                            className={cn(
+                              'w-full text-left p-1.5 rounded-lg transition-colors',
+                              colors.itemBg,
+                              colors.itemHoverBg
+                            )}
+                            aria-label={`View event: ${event.committee}`}
+                          >
+                            <div className="flex items-center gap-1.5">
+                              <EventIcon
+                                branch={event.branch}
+                                className={cn('h-3 w-3 flex-shrink-0', colors.icon)}
+                              />
+                              <span className={cn('text-[11px] font-medium truncate', colors.itemText)}>
+                                {event.time ? `${event.time} · ` : ''}
+                                {event.committee}
+                              </span>
+                            </div>
+                          </button>
+                        );
+                      })}
                     {sortedDayEvents.length > 2 && (
                       <button
                         type="button"

--- a/src/components/calendar/day-events-dialog.tsx
+++ b/src/components/calendar/day-events-dialog.tsx
@@ -2,6 +2,8 @@
 
 import { format } from 'date-fns';
 import type { Event } from '@/lib/types';
+import { getEventColors, getEventCategoryLabel } from '@/lib/event-colors';
+import { cn } from '@/lib/utils';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Separator } from '@/components/ui/separator';
 import { Badge } from '@/components/ui/badge';
@@ -36,33 +38,45 @@ export function DayEventsDialog({ date, events, isOpen, onClose, onSelectEvent }
         </DialogHeader>
         <Separator />
         <div className="space-y-3 py-4">
-          {events.map((event) => (
-            <button
-              key={event.id}
-              type="button"
-              onClick={() => {
-                onSelectEvent(event);
-              }}
-              className="w-full text-left rounded-lg border border-border bg-muted/30 hover:bg-muted/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-            >
-              <div className="flex flex-col gap-2 p-3 sm:p-4">
-                <div className="flex items-center justify-between gap-3">
-                  <div className="flex items-center gap-2">
-                    <EventIcon branch={event.branch} className="h-4 w-4 text-accent" />
-                    <Badge variant="secondary" className="w-fit">
-                      {event.branch}
-                    </Badge>
+          {events.map((event) => {
+            const colors = getEventColors(event);
+            const label = getEventCategoryLabel(event);
+            return (
+              <button
+                key={event.id}
+                type="button"
+                onClick={() => {
+                  onSelectEvent(event);
+                }}
+                className={cn(
+                  'w-full text-left rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                  colors.itemBg,
+                  colors.itemHoverBg,
+                  colors.badgeBorder
+                )}
+              >
+                <div className="flex flex-col gap-2 p-3 sm:p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-2">
+                      <EventIcon branch={event.branch} className={cn('h-4 w-4', colors.icon)} />
+                      <Badge
+                        variant="secondary"
+                        className={cn('w-fit', colors.badgeBg, colors.badgeText, colors.badgeBorder)}
+                      >
+                        {label}
+                      </Badge>
+                    </div>
+                    {event.time && <span className="text-xs text-muted-foreground">{event.time}</span>}
                   </div>
-                  {event.time && <span className="text-xs text-muted-foreground">{event.time}</span>}
+                  <div className="space-y-1">
+                    <p className="text-sm font-semibold text-foreground">{event.committee}</p>
+                    {event.venue && <p className="text-xs text-muted-foreground">Venue: {event.venue}</p>}
+                    {event.agenda && <p className="text-xs text-muted-foreground line-clamp-2">Agenda: {event.agenda}</p>}
+                  </div>
                 </div>
-                <div className="space-y-1">
-                  <p className="text-sm font-semibold text-foreground">{event.committee}</p>
-                  {event.venue && <p className="text-xs text-muted-foreground">Venue: {event.venue}</p>}
-                  {event.agenda && <p className="text-xs text-muted-foreground line-clamp-2">Agenda: {event.agenda}</p>}
-                </div>
-              </div>
-            </button>
-          ))}
+              </button>
+            );
+          })}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/calendar/event-details.tsx
+++ b/src/components/calendar/event-details.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { Event } from '@/lib/types';
+import { getEventColors, getEventCategoryLabel } from '@/lib/event-colors';
 import {
   Dialog,
   DialogContent,
@@ -9,6 +10,7 @@ import {
 } from '@/components/ui/dialog';
 import EventIcon from '@/components/icons/event-icon';
 import { format } from 'date-fns';
+import { cn } from '@/lib/utils';
 import { Separator } from '../ui/separator';
 import { Badge } from '../ui/badge';
 
@@ -20,6 +22,9 @@ interface EventDetailsProps {
 
 export function EventDetails({ event, isOpen, onClose }: EventDetailsProps) {
   if (!event) return null;
+
+  const colors = getEventColors(event);
+  const label = getEventCategoryLabel(event);
 
   const dateSource = event.isoDate ?? (event.date ? `${event.date}T00:00:00` : '');
   const parsedDate = dateSource ? new Date(dateSource) : null;
@@ -43,12 +48,15 @@ export function EventDetails({ event, isOpen, onClose }: EventDetailsProps) {
       <DialogContent className="sm:max-w-[425px] bg-card rounded-xl">
         <DialogHeader>
           <div className="flex items-center gap-4">
-            <div className="bg-accent/10 p-3 rounded-full">
-              <EventIcon branch={event.branch} className="h-6 w-6 text-accent" />
+            <div className={cn(colors.detailIconBg, 'p-3 rounded-full')}>
+              <EventIcon branch={event.branch} className={cn('h-6 w-6', colors.detailIconText)} />
             </div>
             <div className="space-y-1">
-              <Badge variant="secondary" className="w-fit">
-                {event.branch}
+              <Badge
+                variant="secondary"
+                className={cn('w-fit', colors.badgeBg, colors.badgeText, colors.badgeBorder)}
+              >
+                {label}
               </Badge>
               <DialogTitle className="text-2xl font-headline text-foreground">
                 {event.committee}

--- a/src/lib/event-colors.ts
+++ b/src/lib/event-colors.ts
@@ -1,0 +1,77 @@
+import type { Event } from './types';
+
+type EventCategory = 'calendar' | 'house' | 'senate';
+
+type EventColorTokens = {
+  label: string;
+  itemBg: string;
+  itemHoverBg: string;
+  itemText: string;
+  icon: string;
+  badgeBg: string;
+  badgeText: string;
+  badgeBorder: string;
+  detailIconBg: string;
+  detailIconText: string;
+};
+
+const COLOR_MAP: Record<EventCategory, EventColorTokens> = {
+  calendar: {
+    label: 'Legislative Calendar',
+    itemBg: 'bg-amber-100',
+    itemHoverBg: 'hover:bg-amber-200',
+    itemText: 'text-amber-900',
+    icon: 'text-amber-700',
+    badgeBg: 'bg-amber-100',
+    badgeText: 'text-amber-900',
+    badgeBorder: 'border-amber-200',
+    detailIconBg: 'bg-amber-100',
+    detailIconText: 'text-amber-700',
+  },
+  house: {
+    label: 'House of Representatives',
+    itemBg: 'bg-emerald-100',
+    itemHoverBg: 'hover:bg-emerald-200',
+    itemText: 'text-emerald-900',
+    icon: 'text-emerald-700',
+    badgeBg: 'bg-emerald-100',
+    badgeText: 'text-emerald-900',
+    badgeBorder: 'border-emerald-200',
+    detailIconBg: 'bg-emerald-100',
+    detailIconText: 'text-emerald-700',
+  },
+  senate: {
+    label: 'Senate',
+    itemBg: 'bg-sky-100',
+    itemHoverBg: 'hover:bg-sky-200',
+    itemText: 'text-sky-900',
+    icon: 'text-sky-700',
+    badgeBg: 'bg-sky-100',
+    badgeText: 'text-sky-900',
+    badgeBorder: 'border-sky-200',
+    detailIconBg: 'bg-sky-100',
+    detailIconText: 'text-sky-700',
+  },
+};
+
+function isCalendarEvent(event: Event): boolean {
+  if (!event) return false;
+  if (event.id.startsWith('legislative-calendar-')) return true;
+  if (event.source.toLowerCase().includes('calendar')) return true;
+  return false;
+}
+
+function getEventCategory(event: Event): EventCategory {
+  if (isCalendarEvent(event)) return 'calendar';
+  if (event.branch === 'Senate') return 'senate';
+  return 'house';
+}
+
+export function getEventColors(event: Event): EventColorTokens {
+  const category = getEventCategory(event);
+  return COLOR_MAP[category];
+}
+
+export function getEventCategoryLabel(event: Event): string {
+  return COLOR_MAP[getEventCategory(event)].label;
+}


### PR DESCRIPTION
## Summary
- add an event color utility that defines palettes for the legislative calendar, House, and Senate
- update the calendar grid, day dialog, and event details to apply the new color coding and labels based on each event type

## Testing
- not run (npm run lint prompts for configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e4aa2ef018832bb74e614152707d2d